### PR TITLE
修改 DiffUtil.DiffResult 为参数的 setDiffNewData 方法

### DIFF
--- a/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.kt
+++ b/library/src/main/java/com/chad/library/adapter/base/BaseQuickAdapter.kt
@@ -1325,8 +1325,8 @@ abstract class BaseQuickAdapter<T, VH : BaseViewHolder>
             setNewInstance(list)
             return
         }
-        diffResult.dispatchUpdatesTo(BrvahListUpdateCallback(this))
         this.data = list
+        diffResult.dispatchUpdatesTo(BrvahListUpdateCallback(this))
     }
 
     /************************************** Set Listener ****************************************/


### PR DESCRIPTION
```
open fun setDiffNewData(@NonNull diffResult: DiffUtil.DiffResult, list: MutableList<T>) {
        if (hasEmptyView()) {
            // If the current view is an empty view, set the new data directly without diff
            setNewInstance(list)
            return
        }
        diffResult.dispatchUpdatesTo(BrvahListUpdateCallback(this))
        this.data = list
    }
```
这个方法中，this.data = list 是在 diffResult.dispatchUpdatesTo 之后调用的，请问这个调用顺序是有什么特殊作用吗？ 我的理解这会导致 adapter.notify 系列方法触发时，数据源（this.data）依然是旧的，所以提个合并请求

Thank you for contributing to BaseRecyclerViewAdapterHelper. Before pressing the "Create Pull Request" button, please consider the following points:

  - [1] Please give a description about what and why you are contributing, even if it's trivial.

  - [2] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [3] Please include a reasonable set of demo tests if you contribute new code or change an existing one. please make sure you have demo for working correctly.
